### PR TITLE
Add gulp for running jshint now and probably buster later.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,8 +1,21 @@
 {
-  "globalstrict": true,
   "node": true,
   "quotmark": "single",
+  "curly": true,
+  "eqeqeq": true,
+  "es3": true,
+  "forin": true,
+  "indent": 2,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noempty": true,
+  "nonbsp": true,
+  "unused": true,
   "strict": true,
-  "trailing": true,
-  "unused": true
+  "maxparams": 4,
+  "maxdepth": 3,
+  "maxlen": 100,
+  "nomen": true,
+  "trailing": true
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var gulp   = require('gulp');
+var jshint = require('gulp-jshint');
+var path   = require('path');
+
+gulp.task('default', ['lint'], function () {});
+
+gulp.task('lint', function () {
+  gulp
+    .src([
+      path.resolve(__dirname, 'gulpfile.js'),
+      path.resolve(__dirname, 'index.js'),
+      path.resolve(__dirname, 'test', '**', '*.js')
+    ])
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'))
+    .pipe(jshint.instafailReporter());
+});

--- a/index.js
+++ b/index.js
@@ -2,19 +2,26 @@
 
 var Bluebird = require('bluebird');
 
-exports.runSeq = runSeq;
-function runSeq(jobs) {
-  return jobs.reduce(function (job, next) { return job.then(next); }, Bluebird.resolve());
-}
+var partition = function (array, n) {
+  if (array.length === 0) {
+    return [];
+  }
 
-exports.runParallel = runParallel;
-function runParallel(jobs, parallelism) {
-  if (!parallelism) { parallelism = 5; }
-  var partitionedJobs = partition(jobs, Math.ceil(jobs.length / parallelism));
-  return Bluebird.all(partitionedJobs.map(runSeq));
-}
-
-function partition(array, n) {
-  if (array.length === 0) return [];
   return [array.slice(0, n)].concat(partition(array.slice(n), n));
-}
+};
+
+module.exports = {
+  runSeq: function (jobs) {
+    return jobs.reduce(function (job, next) {
+      return job.then(next);
+    }, Bluebird.resolve());
+  },
+
+  runParallel: function (jobs, parallelism) {
+    parallelism = parallelism || 5;
+
+    var partitionedJobs = partition(jobs, Math.ceil(jobs.length / parallelism));
+
+    return Bluebird.all(partitionedJobs.map(this.runSeq));
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Whip your promises into shape!",
   "main": "index.js",
   "scripts": {
-    "test": "jshint index.js test/*.js && buster-test"
+    "test": "gulp && buster-test"
   },
   "repository": {
     "type": "git",
@@ -12,7 +12,8 @@
   },
   "devDependencies": {
     "buster": "~0.7.13",
-    "jshint": "^2.5.6"
+    "gulp": "^3.8.8",
+    "gulp-jshint": "git://github.com/sdepold/gulp-jshint.git#feature/instafail"
   },
   "author": "Contentful GmbH",
   "license": "MIT",


### PR DESCRIPTION
This PR introduces gulp and sets its default task to linting
the project. If there would be a busterjs task, one could also 
add it to the gulpfile. I might write one in the next days.
